### PR TITLE
nohoistを使用して、backendディレクトリ内のnode_modulesにprismaをインストールするようにする

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "backend",
+  "private": true,
   "version": "1.0.0",
   "dependencies": {
     "@prisma/client": "^3.3.0",
@@ -21,5 +22,11 @@
   },
   "engines": {
     "node": ">=14.0.0"
+  },
+  "workspaces": {
+    "nohoist": [
+      "@prisma/client",
+      "prisma"
+    ]
   }
 }


### PR DESCRIPTION
nohoistを使用して、backendディレクトリ内のnode_modulesにprismaをインストールするようにする
https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
Fix #16 